### PR TITLE
Add default careType parameter to URL

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Script to run the hospital finder app
+
+echo "Starting Hospital Finder App..."
+
+# Check if virtual environment exists
+if [ ! -d "env" ]; then
+    echo "Error: Virtual environment not found!"
+    echo "Please run setup first:"
+    echo "  python3 -m venv env"
+    echo "  source env/bin/activate"
+    echo "  pip install -r requirements.txt"
+    exit 1
+fi
+
+# Activate virtual environment
+source env/bin/activate
+
+# Export Node options for legacy OpenSSL support
+export NODE_OPTIONS=--openssl-legacy-provider
+
+# Function to cleanup background processes on exit
+cleanup() {
+    echo "Stopping servers..."
+    kill $DJANGO_PID $NPM_PID 2>/dev/null
+    exit
+}
+
+trap cleanup SIGINT SIGTERM
+
+# Start Django server in background
+echo "Starting Django server..."
+python manage.py runserver &
+DJANGO_PID=$!
+
+# Start npm/webpack in background
+echo "Starting webpack dev server..."
+npm start &
+NPM_PID=$!
+
+# Wait for both processes
+echo "Servers started!"
+echo "Django PID: $DJANGO_PID"
+echo "NPM PID: $NPM_PID"
+echo "Press Ctrl+C to stop all servers"
+
+wait

--- a/static/context/AppContext.js
+++ b/static/context/AppContext.js
@@ -44,6 +44,15 @@ export const AppProvider = ({ children }) => {
 
   // State
   const [careType, setCareType] = useState(initialCareType);
+
+  // Redirect to add careType if missing
+  useEffect(() => {
+    if (!initialCareTypeParam && initialLocationParam) {
+      let redirectUrl = new URL(window.location);
+      redirectUrl.searchParams.set("careType", "Hospital");
+      window.location.href = redirectUrl;
+    }
+  }, []);
   const [sortBy, setSortBy] = useState({ id: 'distance', name: 'Distance' }); // Default to distance
   const [sortDirection, setSortDirection] = useState('asc'); // 'asc' or 'desc' - distance defaults to ascending
   


### PR DESCRIPTION
## Summary
- Automatically adds `careType=Hospital` to URL when missing, ensuring results render properly
- Added `start.sh` script for easy server startup

## Changes
- Modified `AppContext.js` to redirect with default careType when the parameter is missing from the URL
- Created `start.sh` script to run both Django and webpack servers together

## Test plan
- [ ] Visit `http://localhost:8000/?location=38.883333,-77` without careType parameter
- [ ] Verify automatic redirect to include `careType=Hospital`
- [ ] Confirm results render properly after redirect
- [ ] Test `./start.sh` script starts both servers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)