### PR TITLE
Fix search results disappearing on page load

### DIFF
--- a/static/context/AppContext.js
+++ b/static/context/AppContext.js
@@ -45,12 +45,12 @@ export const AppProvider = ({ children }) => {
   // State
   const [careType, setCareType] = useState(initialCareType);
 
-  // Redirect to add careType if missing
+  // Add careType to URL if missing (without reloading)
   useEffect(() => {
     if (!initialCareTypeParam && initialLocationParam) {
-      let redirectUrl = new URL(window.location);
-      redirectUrl.searchParams.set("careType", "Hospital");
-      window.location.href = redirectUrl;
+      let newUrl = new URL(window.location);
+      newUrl.searchParams.set("careType", "Hospital");
+      window.history.replaceState({}, '', newUrl);
     }
   }, []);
   const [sortBy, setSortBy] = useState({ id: 'distance', name: 'Distance' }); // Default to distance


### PR DESCRIPTION
## Summary
- Replace full page redirect with `history.replaceState` when adding careType parameter to URL
- Prevents page reload that was causing search results to disappear after initial render

## Test plan
- [ ] Navigate to https://findqualitycare.org/?location=38.883333,-77 (without careType param)
- [ ] Verify search results remain visible and don't disappear
- [ ] Verify URL is updated to include careType=Hospital parameter
- [ ] Confirm no page reload occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)